### PR TITLE
Switch to builder pattern API

### DIFF
--- a/src/config/drive.rs
+++ b/src/config/drive.rs
@@ -5,23 +5,12 @@ use serde::{Deserialize, Serialize};
 /// Drive configuration.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Drive<'d> {
-    /// drive id
-    pub drive_id: Cow<'d, str>,
-
-    /// is read only
-    pub is_read_only: bool,
-
-    /// is root device
-    pub is_root_device: bool,
-
-    /// Represents the unique id of the boot partition of this device.
-    ///
-    /// It is optional and it will be taken into account only if the is_root_device field is true.
+    drive_id: Cow<'d, str>,
+    is_read_only: bool,
+    is_root_device: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub part_uuid: Option<Cow<'d, str>>,
-
-    /// Host level path for the guest drive
-    pub path_on_host: Cow<'d, Path>,
+    part_uuid: Option<Cow<'d, str>>,
+    pub(crate) path_on_host: Cow<'d, Path>,
     /* TODO:
 
     /// rate limiter
@@ -45,6 +34,31 @@ impl<'d> Drive<'d> {
             part_uuid: None,
             path_on_host: path_on_host.into(),
         })
+    }
+
+    /// The drive ID.
+    pub fn drive_id(&self) -> &str {
+        &self.drive_id
+    }
+
+    /// If the drive is read-only.
+    pub fn is_read_only(&self) -> bool {
+        self.is_read_only
+    }
+
+    /// If the drive is the root device.
+    pub fn is_root_device(&self) -> bool {
+        self.is_root_device
+    }
+
+    /// The unique id of the boot partition of this device.
+    pub fn part_uuid(&self) -> Option<&str> {
+        self.part_uuid.as_deref()
+    }
+
+    /// Host level path for the guest drive.
+    pub fn path_on_host(&self) -> &Path {
+        &self.path_on_host
     }
 }
 

--- a/src/config/drive.rs
+++ b/src/config/drive.rs
@@ -3,8 +3,7 @@ use std::{borrow::Cow, path::Path};
 use serde::{Deserialize, Serialize};
 
 /// Drive configuration.
-// TODO: Provide a builder for `Drive`.
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Drive<'d> {
     /// drive id
     pub drive_id: Cow<'d, str>,
@@ -30,4 +29,55 @@ pub struct Drive<'d> {
     rate_limiter: Option<RateLimiter>,
 
     */
+}
+
+impl<'d> Drive<'d> {
+    /// Create a new `DriveBuilder` instance.
+    pub fn builder<I, P>(drive_id: I, path_on_host: P) -> DriveBuilder<'d>
+    where
+        I: Into<Cow<'d, str>>,
+        P: Into<Cow<'d, Path>>,
+    {
+        DriveBuilder(Drive {
+            drive_id: drive_id.into(),
+            is_read_only: false,
+            is_root_device: false,
+            part_uuid: None,
+            path_on_host: path_on_host.into(),
+        })
+    }
+}
+
+/// Builder for `Drive`.
+#[derive(Debug)]
+pub struct DriveBuilder<'d>(Drive<'d>);
+
+impl<'d> DriveBuilder<'d> {
+    /// If to-be-created `Drive` will be read-only.
+    pub fn is_read_only(mut self, is_read_only: bool) -> Self {
+        self.0.is_read_only = is_read_only;
+        self
+    }
+
+    /// If to-be-created `Drive` will be the root device.
+    pub fn is_root_device(mut self, is_root_device: bool) -> Self {
+        self.0.is_root_device = is_root_device;
+        self
+    }
+
+    /// Set the unique id of the boot partition of this device.
+    ///
+    /// It is optional and it will be taken into account only if its root device.
+    pub fn part_uuid<U>(mut self, part_uuid: Option<U>) -> Self
+    where
+        U: Into<Cow<'d, str>>,
+    {
+        self.0.part_uuid = part_uuid.map(Into::into);
+        self
+    }
+
+    /// Build the `Drive`.
+    pub fn build(self) -> Drive<'d> {
+        self.0
+    }
 }

--- a/src/config/jailer.rs
+++ b/src/config/jailer.rs
@@ -5,20 +5,14 @@ use std::{borrow::Cow, path::Path};
 use uuid::Uuid;
 
 /// Jailer specific configuration needed to execute the jailer.
-#[derive(Derivative, Debug)]
-#[derivative(Default)]
+#[derive(Debug)]
 pub struct Jailer<'c> {
-    #[derivative(Default(value = "users::get_effective_gid()"))]
     gid: u32,
-    #[derivative(Default(value = "users::get_effective_uid()"))]
     uid: u32,
-    #[derivative(Default(value = "uuid::Uuid::new_v4()"))]
     id: Uuid,
     numa_node: Option<i32>,
     exec_file: Cow<'c, Path>,
-    #[derivative(Default(value = "Path::new(\"jailer\").into()"))]
     jailer_binary: Cow<'c, Path>,
-    #[derivative(Default(value = "Path::new(\"/srv/jailer\").into()"))]
     chroot_base_dir: Cow<'c, Path>,
     pub(crate) mode: JailerMode,
     // TODO: We need an equivalent of ChrootStrategy.

--- a/src/config/jailer.rs
+++ b/src/config/jailer.rs
@@ -6,21 +6,21 @@ use uuid::Uuid;
 
 /// Jailer specific configuration needed to execute the jailer.
 #[derive(Debug)]
-pub struct Jailer<'c> {
+pub struct Jailer<'j> {
     gid: u32,
     uid: u32,
     id: Uuid,
     numa_node: Option<i32>,
-    exec_file: Cow<'c, Path>,
-    jailer_binary: Cow<'c, Path>,
-    chroot_base_dir: Cow<'c, Path>,
+    exec_file: Cow<'j, Path>,
+    jailer_binary: Cow<'j, Path>,
+    chroot_base_dir: Cow<'j, Path>,
     pub(crate) mode: JailerMode,
     // TODO: We need an equivalent of ChrootStrategy.
 }
 
-impl<'c> Jailer<'c> {
+impl<'j> Jailer<'j> {
     /// Create a new `JailerBuilder` instance.
-    pub fn builder() -> JailerBuilder<'c> {
+    pub fn builder() -> JailerBuilder<'j> {
         JailerBuilder(Jailer {
             gid: users::get_effective_gid(),
             uid: users::get_effective_uid(),
@@ -99,9 +99,9 @@ pub struct Stdio {
 
 /// Builder for `Jailer` instances.
 #[derive(Debug)]
-pub struct JailerBuilder<'c>(Jailer<'c>);
+pub struct JailerBuilder<'j>(Jailer<'j>);
 
-impl<'c> JailerBuilder<'c> {
+impl<'j> JailerBuilder<'j> {
     /// GID the jailer switches to as it execs the target binary.
     pub fn gid(mut self, gid: u32) -> Self {
         self.0.gid = gid;
@@ -135,7 +135,7 @@ impl<'c> JailerBuilder<'c> {
     /// with the jailer is mostly Firecracker specific.
     pub fn exec_file<P>(mut self, exec_file: P) -> Self
     where
-        P: Into<Cow<'c, Path>>,
+        P: Into<Cow<'j, Path>>,
     {
         self.0.exec_file = exec_file.into();
         self
@@ -151,7 +151,7 @@ impl<'c> JailerBuilder<'c> {
     /// If not specified it defaults to "jailer".
     pub fn jailer_binary<P>(mut self, jailer_binary: P) -> Self
     where
-        P: Into<Cow<'c, Path>>,
+        P: Into<Cow<'j, Path>>,
     {
         self.0.jailer_binary = jailer_binary.into();
         self
@@ -162,7 +162,7 @@ impl<'c> JailerBuilder<'c> {
     /// The default is `/srv/jailer`.
     pub fn chroot_base_dir<P>(mut self, chroot_base_dir: P) -> Self
     where
-        P: Into<Cow<'c, Path>>,
+        P: Into<Cow<'j, Path>>,
     {
         self.0.chroot_base_dir = chroot_base_dir.into();
         self
@@ -175,7 +175,7 @@ impl<'c> JailerBuilder<'c> {
     }
 
     /// Build the `Jailer` instance.
-    pub fn build(self) -> Jailer<'c> {
+    pub fn build(self) -> Jailer<'j> {
         self.0
     }
 }

--- a/src/config/jailer.rs
+++ b/src/config/jailer.rs
@@ -5,7 +5,6 @@ use std::{borrow::Cow, path::Path};
 use uuid::Uuid;
 
 /// Jailer specific configuration needed to execute the jailer.
-// TODO: Provide a builder for `Jailer`.
 #[derive(Derivative, Debug)]
 #[derivative(Default)]
 pub struct Jailer<'c> {
@@ -51,6 +50,22 @@ pub struct Jailer<'c> {
     // TODO: We need an equivalent of ChrootStrategy.
 }
 
+impl<'c> Jailer<'c> {
+    /// Create a new `JailerBuilder` instance.
+    pub fn builder() -> JailerBuilder<'c> {
+        JailerBuilder(Jailer {
+            gid: users::get_effective_gid(),
+            uid: users::get_effective_uid(),
+            id: uuid::Uuid::new_v4(),
+            numa_node: None,
+            exec_file: Path::new("/usr/bin/firecracker").into(),
+            jailer_binary: Path::new("jailer").into(),
+            chroot_base_dir: Path::new("/srv/jailer").into(),
+            mode: JailerMode::default(),
+        })
+    }
+}
+
 /// The mode of the jailer process.
 #[derive(Derivative)]
 #[derivative(Debug, Default)]
@@ -72,4 +87,87 @@ pub struct Stdio {
     pub stderr: Option<std::process::Stdio>,
     /// Stdin specifies the IO reader for STDIN to use when spawning the jailer.
     pub stdin: Option<std::process::Stdio>,
+}
+
+/// Builder for `Jailer` instances.
+#[derive(Debug)]
+pub struct JailerBuilder<'c>(Jailer<'c>);
+
+impl<'c> JailerBuilder<'c> {
+    /// GID the jailer switches to as it execs the target binary.
+    pub fn gid(mut self, gid: u32) -> Self {
+        self.0.gid = gid;
+        self
+    }
+
+    /// UID the jailer switches to as it execs the target binary.
+    pub fn uid(mut self, uid: u32) -> Self {
+        self.0.uid = uid;
+        self
+    }
+
+    /// The unique VM identification string
+    ///
+    /// This may contain alphanumeric characters and hyphens. The maximum id length is currently 64
+    /// characters
+    pub fn id(mut self, id: Uuid) -> Self {
+        self.0.id = id;
+        self
+    }
+
+    /// NumaNode represents the NUMA node the process gets assigned to.
+    pub fn numa_node(mut self, numa_node: i32) -> Self {
+        self.0.numa_node = Some(numa_node);
+        self
+    }
+
+    /// The path to the Firecracker binary that will be exec-ed by the jailer.
+    ///
+    /// The user can provide a path to any binary, but the interaction
+    /// with the jailer is mostly Firecracker specific.
+    pub fn exec_file<P>(mut self, exec_file: P) -> Self
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        self.0.exec_file = exec_file.into();
+        self
+    }
+
+    /// Specifies the jailer binary to be used for setting up the Firecracker VM jail.
+    ///
+    /// If the value contains no path separators, it will use the PATH environment variable to get
+    /// the absolute path of the binary. If the value contains path separators, the value will be
+    /// used directly to exec the jailer. This follows the same conventions as Golang's
+    /// os/exec.Command.
+    //
+    /// If not specified it defaults to "jailer".
+    pub fn jailer_binary<P>(mut self, jailer_binary: P) -> Self
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        self.0.jailer_binary = jailer_binary.into();
+        self
+    }
+
+    /// The base folder where chroot jails are built.
+    ///
+    /// The default is `/srv/jailer`.
+    pub fn chroot_base_dir<P>(mut self, chroot_base_dir: P) -> Self
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        self.0.chroot_base_dir = chroot_base_dir.into();
+        self
+    }
+
+    /// The mode of the jailer process.
+    pub fn mode(mut self, mode: JailerMode) -> Self {
+        self.0.mode = mode;
+        self
+    }
+
+    /// Build the `Jailer` instance.
+    pub fn build(self) -> Jailer<'c> {
+        self.0
+    }
 }

--- a/src/config/jailer.rs
+++ b/src/config/jailer.rs
@@ -8,45 +8,19 @@ use uuid::Uuid;
 #[derive(Derivative, Debug)]
 #[derivative(Default)]
 pub struct Jailer<'c> {
-    /// GID the jailer switches to as it execs the target binary.
     #[derivative(Default(value = "users::get_effective_gid()"))]
-    pub gid: u32,
-
-    /// UID the jailer switches to as it execs the target binary.
+    gid: u32,
     #[derivative(Default(value = "users::get_effective_uid()"))]
-    pub uid: u32,
-
-    /// The unique VM identification string, which may contain alphanumeric
-    /// characters and hyphens. The maximum id length is currently 64 characters
+    uid: u32,
     #[derivative(Default(value = "uuid::Uuid::new_v4()"))]
-    pub id: Uuid,
-
-    /// NumaNode represents the NUMA node the process gets assigned to.
-    pub numa_node: Option<i32>,
-
-    /// The path to the Firecracker binary that will be exec-ed by
-    /// the jailer. The user can provide a path to any binary, but the interaction
-    /// with the jailer is mostly Firecracker specific.
-    pub exec_file: Cow<'c, Path>,
-
-    /// Specifies the jailer binary to be used for setting up the
-    /// Firecracker VM jail. If the value contains no path separators, it will
-    /// use the PATH environment variable to get the absolute path of the binary.
-    /// If the value contains path separators, the value will be used directly
-    /// to exec the jailer. This follows the same conventions as Golang's
-    /// os/exec.Command.
-    //
-    /// If not specified it defaults to "jailer".
+    id: Uuid,
+    numa_node: Option<i32>,
+    exec_file: Cow<'c, Path>,
     #[derivative(Default(value = "Path::new(\"jailer\").into()"))]
-    pub jailer_binary: Cow<'c, Path>,
-
-    /// represents the base folder where chroot jails are built. The
-    /// default is `/srv/jailer`.
+    jailer_binary: Cow<'c, Path>,
     #[derivative(Default(value = "Path::new(\"/srv/jailer\").into()"))]
-    pub chroot_base_dir: Cow<'c, Path>,
-
-    /// The mode of the jailer process.
-    pub mode: JailerMode,
+    chroot_base_dir: Cow<'c, Path>,
+    pub(crate) mode: JailerMode,
     // TODO: We need an equivalent of ChrootStrategy.
 }
 
@@ -63,6 +37,46 @@ impl<'c> Jailer<'c> {
             chroot_base_dir: Path::new("/srv/jailer").into(),
             mode: JailerMode::default(),
         })
+    }
+
+    /// GID the jailer switches to as it execs the target binary.
+    pub fn gid(&self) -> u32 {
+        self.gid
+    }
+
+    /// UID the jailer switches to as it execs the target binary.
+    pub fn uid(&self) -> u32 {
+        self.uid
+    }
+
+    /// The unique VM identification.
+    pub fn id(&self) -> &Uuid {
+        &self.id
+    }
+
+    /// The NUMA node the process gets assigned to.
+    pub fn numa_node(&self) -> Option<i32> {
+        self.numa_node
+    }
+
+    /// The path to the Firecracker binary that will be exec-ed by the jailer.
+    pub fn exec_file(&self) -> &Path {
+        &self.exec_file
+    }
+
+    /// Specifies the jailer binary to be used for setting up the Firecracker VM jail.
+    pub fn jailer_binary(&self) -> &Path {
+        &self.jailer_binary
+    }
+
+    /// The base folder where chroot jails are built.
+    pub fn chroot_base_dir(&self) -> &Path {
+        &self.chroot_base_dir
+    }
+
+    /// The mode of the jailer process.
+    pub fn mode(&self) -> &JailerMode {
+        &self.mode
     }
 }
 

--- a/src/config/machine.rs
+++ b/src/config/machine.rs
@@ -6,29 +6,14 @@ use serde::{Deserialize, Serialize};
 /// Machine configuration.
 #[derive(Derivative, Debug, Serialize, Deserialize, Default)]
 pub struct Machine<'m> {
-    /// Flag for enabling/disabling simultaneous multithreading. Can be enabled only on x86.
-    pub smt: bool,
-
-    /// Enable dirty page tracking. If this is enabled, then incremental guest memory snapshots
-    /// can be created. These belong to diff snapshots, which contain, besides the microVM state,
-    /// only the memory dirtied since a previous snapshot. Full snapshots each contain a full copy
-    /// of the guest memory.
-    pub track_dirty_pages: bool,
-
-    /// Memory size of VM
-    pub mem_size_mib: i64,
-
-    /// Number of vCPUs (either 1 or an even number)
-    ///
-    /// Maximum: 32
-    /// Minimum: 1
+    smt: bool,
+    track_dirty_pages: bool,
+    mem_size_mib: i64,
     #[derivative(Default(value = "1"))]
-    pub vcpu_count: usize,
-
-    /// cpu template
+    vcpu_count: usize,
     // TODO: Should create a type to validate it like the Go API.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cpu_template: Option<Cow<'m, str>>,
+    cpu_template: Option<Cow<'m, str>>,
 }
 
 impl<'m> Machine<'m> {
@@ -41,6 +26,31 @@ impl<'m> Machine<'m> {
             vcpu_count: 1,
             cpu_template: None,
         })
+    }
+
+    /// If simultaneous multithreading is enabled.
+    pub fn smt(&self) -> bool {
+        self.smt
+    }
+
+    /// If dirty page tracking is enabled.
+    pub fn track_dirty_pages(&self) -> bool {
+        self.track_dirty_pages
+    }
+
+    /// Memory size of VM.
+    pub fn mem_size_mib(&self) -> i64 {
+        self.mem_size_mib
+    }
+
+    /// Number of vCPUs (either 1 or an even number)
+    pub fn vcpu_count(&self) -> usize {
+        self.vcpu_count
+    }
+
+    /// CPU template.
+    pub fn cpu_template(&self) -> Option<&str> {
+        self.cpu_template.as_deref()
     }
 }
 

--- a/src/config/machine.rs
+++ b/src/config/machine.rs
@@ -4,7 +4,6 @@ use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
 /// Machine configuration.
-// TODO: Provide a builder for `Machine`.
 #[derive(Derivative, Debug, Serialize, Deserialize, Default)]
 pub struct Machine<'m> {
     /// Flag for enabling/disabling simultaneous multithreading. Can be enabled only on x86.
@@ -30,4 +29,66 @@ pub struct Machine<'m> {
     // TODO: Should create a type to validate it like the Go API.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_template: Option<Cow<'m, str>>,
+}
+
+impl<'m> Machine<'m> {
+    /// Create a new `MachineBuilder` instance.
+    pub fn builder() -> MachineBuilder<'m> {
+        MachineBuilder(Machine {
+            smt: false,
+            track_dirty_pages: false,
+            mem_size_mib: 0,
+            vcpu_count: 1,
+            cpu_template: None,
+        })
+    }
+}
+
+/// Builder for `Machine`.
+#[derive(Debug)]
+pub struct MachineBuilder<'m>(Machine<'m>);
+
+impl<'m> MachineBuilder<'m> {
+    /// Flag for enabling/disabling simultaneous multithreading.
+    ///
+    /// Can be enabled only on x86.
+    pub fn smt(mut self, smt: bool) -> Self {
+        self.0.smt = smt;
+        self
+    }
+
+    /// Enable dirty page tracking. If this is enabled, then incremental guest memory snapshots
+    /// can be created. These belong to diff snapshots, which contain, besides the microVM state,
+    /// only the memory dirtied since a previous snapshot. Full snapshots each contain a full copy
+    /// of the guest memory.
+    pub fn track_dirty_pages(mut self, track_dirty_pages: bool) -> Self {
+        self.0.track_dirty_pages = track_dirty_pages;
+        self
+    }
+
+    /// Memory size of VM.
+    pub fn mem_size_mib(mut self, mem_size_mib: i64) -> Self {
+        self.0.mem_size_mib = mem_size_mib;
+        self
+    }
+
+    /// Number of vCPUs (either 1 or an even number).
+    ///
+    /// Maximum: 32
+    /// Minimum: 1
+    pub fn vcpu_count(mut self, vcpu_count: usize) -> Self {
+        self.0.vcpu_count = vcpu_count;
+        self
+    }
+
+    /// cpu template.
+    pub fn cpu_template(mut self, cpu_template: Cow<'m, str>) -> Self {
+        self.0.cpu_template = Some(cpu_template);
+        self
+    }
+
+    /// Build the `Machine` instance.
+    pub fn build(self) -> Machine<'m> {
+        self.0
+    }
 }

--- a/src/config/machine.rs
+++ b/src/config/machine.rs
@@ -4,12 +4,11 @@ use derivative::Derivative;
 use serde::{Deserialize, Serialize};
 
 /// Machine configuration.
-#[derive(Derivative, Debug, Serialize, Deserialize, Default)]
+#[derive(Derivative, Debug, Serialize, Deserialize)]
 pub struct Machine<'m> {
     smt: bool,
     track_dirty_pages: bool,
     mem_size_mib: i64,
-    #[derivative(Default(value = "1"))]
     vcpu_count: usize,
     // TODO: Should create a type to validate it like the Go API.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -38,11 +38,11 @@ pub struct Config<'c> {
     pub log_level: Option<LogLevel>,
 
     /// defines the file path where the Firecracker metrics is located.
-    pub metrics_path: Cow<'c, Path>,
+    pub metrics_path: Option<Cow<'c, Path>>,
 
     /// defines the file path where the Firecracker metrics
     /// named-pipe should be located.
-    pub metrics_fifo: Cow<'c, Path>,
+    pub metrics_fifo: Option<Cow<'c, Path>>,
 
     /// defines the file path where the kernel image is located.
     /// The kernel image must be an uncompressed ELF image.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,9 +17,8 @@ pub use machine::*;
 use uuid::Uuid;
 
 /// VMM configuration.
-// TODO: Provide a builder for `Config`.
 #[derive(Derivative)]
-#[derivative(Debug, Default)]
+#[derivative(Debug)]
 pub struct Config<'c> {
     /// defines the file path where the Firecracker control socket
     /// should be created.
@@ -76,7 +75,7 @@ pub struct Config<'c> {
     /// random uuid if not provided by the user. It's used to set Firecracker's instance ID.
     /// If CNI configuration is provided as part of NetworkInterfaces,
     /// the VMID is used to set CNI ContainerID and create a network namespace path.
-    pub vm_id: Option<Uuid>,
+    pub vm_id: Uuid,
 
     /// represents the path to a network namespace handle. If present, the
     /// application will use this to join the associated network namespace
@@ -94,6 +93,34 @@ pub struct Config<'c> {
 }
 
 impl<'c> Config<'c> {
+    /// Create a new `Builder` instance.
+    ///
+    /// # Arguments
+    ///
+    /// `kernel_image_path: The path to the kernel image, that must be an uncompressed ELF image.
+    pub fn builder<P>(kernel_image_path: P) -> Builder<'c>
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        Builder(Self {
+            socket_path: Path::new("/run/firecracker.socket").into(),
+            log_path: None,
+            log_fifo: None,
+            log_level: None,
+            metrics_path: None,
+            metrics_fifo: None,
+            kernel_image_path: kernel_image_path.into(),
+            initrd_path: None,
+            kernel_args: None,
+            drives: Vec::new(),
+            machine_cfg: Machine::builder().build(),
+            jailer_cfg: None,
+            vm_id: Uuid::new_v4(),
+            net_ns: None,
+            network_interfaces: Vec::new(),
+        })
+    }
+
     /// Create boot source from `self`.
     pub fn boot_source(&self) -> BootSource<'_> {
         BootSource {
@@ -130,4 +157,133 @@ pub enum LogLevel {
     Info,
     /// Debug level logging.
     Debug,
+}
+
+/// Configuration builder.
+#[derive(Debug)]
+pub struct Builder<'c>(Config<'c>);
+
+impl<'c> Builder<'c> {
+    /// Set the file path where the Firecracker control socket should be created.
+    pub fn socket_path<P>(mut self, socket_path: P) -> Self
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        self.0.socket_path = socket_path.into();
+        self
+    }
+
+    /// Set the Firecracker log path.
+    pub fn log_path<P>(mut self, log_path: Option<P>) -> Self
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        self.0.log_path = log_path.map(Into::into);
+        self
+    }
+
+    /// Set the Firecracker log named-pipe path.
+    pub fn log_fifo<P>(mut self, log_fifo: Option<P>) -> Self
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        self.0.log_fifo = log_fifo.map(Into::into);
+        self
+    }
+
+    /// Set the verbosity of Firecracker logging.
+    pub fn log_level(mut self, log_level: Option<LogLevel>) -> Self {
+        self.0.log_level = log_level;
+        self
+    }
+
+    /// Set the Firecracker metrics path.
+    pub fn metrics_path<P>(mut self, metrics_path: Option<P>) -> Self
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        self.0.metrics_path = metrics_path.map(Into::into);
+        self
+    }
+
+    /// Set the Firecracker metrics named-pipe path.
+    pub fn metrics_fifo<P>(mut self, metrics_fifo: Option<P>) -> Self
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        self.0.metrics_fifo = metrics_fifo.map(Into::into);
+        self
+    }
+
+    /// Set the initrd image path.
+    pub fn initrd_path<P>(mut self, initrd_path: Option<P>) -> Self
+    where
+        P: Into<Cow<'c, Path>>,
+    {
+        self.0.initrd_path = initrd_path.map(Into::into);
+        self
+    }
+
+    /// Set the command-line arguments that should be passed to the kernel.
+    pub fn kernel_args<P>(mut self, kernel_args: Option<P>) -> Self
+    where
+        P: Into<Cow<'c, str>>,
+    {
+        self.0.kernel_args = kernel_args.map(Into::into);
+        self
+    }
+
+    /// Add a drive.
+    pub fn add_drive<D>(mut self, drive: D) -> Self
+    where
+        D: Into<Drive<'c>>,
+    {
+        self.0.drives.push(drive.into());
+        self
+    }
+
+    /// Set the Firecracker microVM process configuration.
+    pub fn machine_cfg(mut self, machine_cfg: Machine<'c>) -> Self {
+        self.0.machine_cfg = machine_cfg;
+        self
+    }
+
+    /// Set the jailer process configuration.
+    pub fn jailer_cfg(mut self, jailer_cfg: Option<Jailer<'c>>) -> Self {
+        self.0.jailer_cfg = jailer_cfg;
+        self
+    }
+
+    /// Set a unique identifier for this VM.
+    ///
+    /// It's set to a random uuid if not provided by the user. It's used as the Firecracker's
+    /// instance ID.
+    pub fn vm_id(mut self, vm_id: Uuid) -> Self {
+        self.0.vm_id = vm_id;
+        self
+    }
+
+    /// Set the path to a network namespace handle.
+    ///
+    /// If specified, the application will use this to join the associated network namespace.
+    pub fn net_ns<N>(mut self, net_ns: Option<N>) -> Self
+    where
+        N: Into<Cow<'c, str>>,
+    {
+        self.0.net_ns = net_ns.map(Into::into);
+        self
+    }
+
+    /// Add a network interface.
+    ///
+    /// Add a tap device that should be made available to the microVM.
+    pub fn add_network_interface(mut self, network_interface: network::Interface<'c>) -> Self {
+        self.0.network_interfaces.push(network_interface);
+        self
+    }
+
+    /// Build the configuration.
+    pub fn build(self) -> Config<'c> {
+        self.0
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,70 +20,28 @@ use uuid::Uuid;
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct Config<'c> {
-    /// defines the file path where the Firecracker control socket
-    /// should be created.
     #[derivative(Default(value = "Path::new(\"/run/firecracker.socket\").into()"))]
-    pub socket_path: Cow<'c, Path>,
-
-    /// defines the file path where the Firecracker log is located.
-    pub log_path: Option<Cow<'c, Path>>,
-
-    /// defines the file path where the Firecracker log named-pipe should
-    /// be located.
-    pub log_fifo: Option<Cow<'c, Path>>,
-
-    /// defines the verbosity of Firecracker logging.  Valid values are
-    /// "Error", "Warning", "Info", and "Debug", and are case-sensitive.
-    pub log_level: Option<LogLevel>,
-
-    /// defines the file path where the Firecracker metrics is located.
-    pub metrics_path: Option<Cow<'c, Path>>,
-
-    /// defines the file path where the Firecracker metrics
-    /// named-pipe should be located.
-    pub metrics_fifo: Option<Cow<'c, Path>>,
-
-    /// defines the file path where the kernel image is located.
-    /// The kernel image must be an uncompressed ELF image.
-    pub kernel_image_path: Cow<'c, Path>,
-
-    /// defines the file path where initrd image is located.
-    ///
-    /// This parameter is optional.
-    pub initrd_path: Option<Cow<'c, Path>>,
-
-    /// defines the command-line arguments that should be passed to
-    /// the kernel.
-    pub kernel_args: Option<Cow<'c, str>>,
-
-    /// specifies BlockDevices that should be made available to the
-    /// microVM.
-    pub drives: Vec<Drive<'c>>,
+    pub(crate) socket_path: Cow<'c, Path>,
+    log_path: Option<Cow<'c, Path>>,
+    log_fifo: Option<Cow<'c, Path>>,
+    log_level: Option<LogLevel>,
+    metrics_path: Option<Cow<'c, Path>>,
+    metrics_fifo: Option<Cow<'c, Path>>,
+    pub(crate) kernel_image_path: Cow<'c, Path>,
+    pub(crate) initrd_path: Option<Cow<'c, Path>>,
+    kernel_args: Option<Cow<'c, str>>,
+    pub(crate) drives: Vec<Drive<'c>>,
 
     // FIXME: Can't use trait object here because it's make `Config` non-Send, which is problematic
     // for async/await.
     //// Used to redirect the contents of the fifo log to the writer.
     //#[derivative(Debug = "ignore")]
     //pub fifo_log_writer: Option<Box<dyn AsyncWrite>>,
-    /// The firecracker microVM process configuration
-    pub machine_cfg: Machine<'c>,
-
-    /// JailerCfg is configuration specific for the jailer process.
-    pub jailer_cfg: Option<Jailer<'c>>,
-
-    /// a unique identifier for this VM. It's set to a
-    /// random uuid if not provided by the user. It's used to set Firecracker's instance ID.
-    /// If CNI configuration is provided as part of NetworkInterfaces,
-    /// the VMID is used to set CNI ContainerID and create a network namespace path.
-    pub vm_id: Uuid,
-
-    /// represents the path to a network namespace handle. If present, the
-    /// application will use this to join the associated network namespace
-    pub net_ns: Option<Cow<'c, str>>,
-
-    /// specifies the tap devices that should be made available
-    /// to the microVM.
-    pub network_interfaces: Vec<network::Interface<'c>>,
+    machine_cfg: Machine<'c>,
+    pub(crate) jailer_cfg: Option<Jailer<'c>>,
+    vm_id: Uuid,
+    net_ns: Option<Cow<'c, str>>,
+    network_interfaces: Vec<network::Interface<'c>>,
     /* TODO:
 
 
@@ -128,6 +86,76 @@ impl<'c> Config<'c> {
             initrd_path: self.initrd_path.as_ref().map(AsRef::as_ref),
             boot_args: self.kernel_args.as_ref().map(AsRef::as_ref),
         }
+    }
+
+    /// The socket path.
+    pub fn socket_path(&self) -> &Path {
+        self.socket_path.as_ref()
+    }
+
+    /// The log path.
+    pub fn log_path(&self) -> Option<&Path> {
+        self.log_path.as_ref().map(AsRef::as_ref)
+    }
+
+    /// The log fifo path.
+    pub fn log_fifo(&self) -> Option<&Path> {
+        self.log_fifo.as_ref().map(AsRef::as_ref)
+    }
+
+    /// The metrics path.
+    pub fn metrics_path(&self) -> Option<&Path> {
+        self.metrics_path.as_ref().map(AsRef::as_ref)
+    }
+
+    /// The metrics fifo path.
+    pub fn metrics_fifo(&self) -> Option<&Path> {
+        self.metrics_fifo.as_ref().map(AsRef::as_ref)
+    }
+
+    /// The kernel image path.
+    pub fn kernel_image_path(&self) -> &Path {
+        self.kernel_image_path.as_ref()
+    }
+
+    /// The initrd path.
+    pub fn initrd_path(&self) -> Option<&Path> {
+        self.initrd_path.as_ref().map(AsRef::as_ref)
+    }
+
+    /// The kernel arguments.
+    pub fn kernel_args(&self) -> Option<&str> {
+        self.kernel_args.as_ref().map(AsRef::as_ref)
+    }
+
+    /// The drives.
+    pub fn drives(&self) -> &[Drive<'c>] {
+        &self.drives
+    }
+
+    /// The machine configuration.
+    pub fn machine_cfg(&self) -> &Machine<'c> {
+        &self.machine_cfg
+    }
+
+    /// The jailer configuration.
+    pub fn jailer_cfg(&self) -> Option<&Jailer<'c>> {
+        self.jailer_cfg.as_ref()
+    }
+
+    /// The VM ID.
+    pub fn vm_id(&self) -> &Uuid {
+        &self.vm_id
+    }
+
+    /// The network namespace path.
+    pub fn net_ns(&self) -> Option<&str> {
+        self.net_ns.as_ref().map(AsRef::as_ref)
+    }
+
+    /// The network interfaces.
+    pub fn network_interfaces(&self) -> &[network::Interface<'c>] {
+        &self.network_interfaces
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,10 +17,8 @@ pub use machine::*;
 use uuid::Uuid;
 
 /// VMM configuration.
-#[derive(Derivative)]
-#[derivative(Debug)]
+#[derive(Debug)]
 pub struct Config<'c> {
-    #[derivative(Default(value = "Path::new(\"/run/firecracker.socket\").into()"))]
     pub(crate) socket_path: Cow<'c, Path>,
     log_path: Option<Cow<'c, Path>>,
     log_fifo: Option<Cow<'c, Path>>,

--- a/src/config/network.rs
+++ b/src/config/network.rs
@@ -2,34 +2,10 @@ use std::borrow::Cow;
 
 /// Network configuration.
 #[derive(Debug)]
-pub enum Interface<'i> {
-    /// CNIConfiguration that will be used to generate the VM's network namespace,
-    /// tap device and internal network for this network interface.
-    Cni(Cni<'i>),
-}
+pub struct Interface<'i> {
+    /// The name of the host interface.
+    pub host_if_name: Cow<'i, str>,
 
-/// CNI network configuration.
-// TODO: Provide a builder for `Cni`.
-#[derive(Debug, Default)]
-pub struct Cni<'c> {
-    /// Corresponds to the "name" parameter in the CNI spec's
-    /// Network Configuration List structure. It selects the name
-    /// of the network whose configuration will be used when invoking CNI.
-    pub network_name: Cow<'c, str>,
-
-    /// IfName (optional) corresponds to the CNI_IFNAME parameter as specified
-    /// in the CNI spec. It generally specifies the name of the interface to be
-    /// created by a CNI plugin being invoked.
-    ///
-    /// Note that this does NOT necessarily correspond to the name of the
-    /// tap device the Firecracker VM will use as the tap device may be
-    /// created by a chained plugin that adapts the tap to a pre-existing
-    /// network device (which will by the one with "IfName").
-    pub if_name: Option<Cow<'c, str>>,
-
-    /// Sets the interface name in the VM. It is used
-    /// to correctly pass IP configuration obtained from the CNI to the VM kernel.
-    /// It can be left blank for VMs with single network interface.
-    pub vm_if_name: Option<Cow<'c, str>>,
-    // TODO: Other fields: https://pkg.go.dev/github.com/firecracker-microvm/firecracker-go-sdk#CNIConfiguration
+    /// The interface name in the VM.
+    pub vm_if_name: Cow<'i, str>,
 }

--- a/src/config/network.rs
+++ b/src/config/network.rs
@@ -3,9 +3,42 @@ use std::borrow::Cow;
 /// Network configuration.
 #[derive(Debug)]
 pub struct Interface<'i> {
+    host_if_name: Cow<'i, str>,
+    vm_if_name: Cow<'i, str>,
+}
+
+impl<'i> Interface<'i> {
+    /// Create a new `Interface` instance.
+    pub fn new<H, V>(host_if_name: H, vm_if_name: V) -> Self
+    where
+        H: Into<Cow<'i, str>>,
+        V: Into<Cow<'i, str>>,
+    {
+        Interface {
+            host_if_name: host_if_name.into(),
+            vm_if_name: vm_if_name.into(),
+        }
+    }
+
     /// The name of the host interface.
-    pub host_if_name: Cow<'i, str>,
+    pub fn host_if_name(&self) -> &str {
+        &self.host_if_name
+    }
 
     /// The interface name in the VM.
-    pub vm_if_name: Cow<'i, str>,
+    pub fn vm_if_name(&self) -> &str {
+        &self.vm_if_name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[ignore]
+    fn string_generics() {
+        // Compile-only test to ensure the generics work for both string types.
+        let _ = super::Interface::new("host_if_name", "vm_if_name");
+        // Different types are fine, as long as they've the same lifetime.
+        let _ = super::Interface::new("host_if_name".to_string(), "vm_if_name");
+    }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -68,12 +68,12 @@ impl<'m> Machine<'m> {
 
         // Assemble the path to the jailed root folder on the host.
         let exec_file_base = jailer
-            .exec_file
+            .exec_file()
             .file_name()
             .ok_or(Error::InvalidJailerExecPath)?;
-        let id_str = jailer.id.to_string();
+        let id_str = jailer.id().to_string();
         let jailer_workspace_dir = jailer
-            .chroot_base_dir
+            .chroot_base_dir()
             .join(exec_file_base)
             .join(&id_str)
             .join("root");
@@ -159,23 +159,23 @@ impl<'m> Machine<'m> {
 
         // TODO: Handle fifos. See https://github.com/firecracker-microvm/firecracker-go-sdk/blob/f0a967ef386caec37f6533dce5797038edf8c226/jailer.go#L435
 
-        let mut cmd = Command::new(jailer.jailer_binary.as_os_str());
+        let mut cmd = Command::new(jailer.jailer_binary().as_os_str());
         let mut cmd = cmd
             .args(&[
                 "--id",
                 &id_str,
                 "--exec-file",
                 jailer
-                    .exec_file
+                    .exec_file()
                     .to_str()
                     .ok_or(Error::InvalidJailerExecPath)?,
                 "--uid",
-                &jailer.uid.to_string(),
+                &jailer.uid().to_string(),
                 "--gid",
-                &jailer.gid.to_string(),
+                &jailer.gid().to_string(),
                 "--chroot-base-dir",
                 jailer
-                    .chroot_base_dir
+                    .chroot_base_dir()
                     .to_str()
                     .ok_or(Error::InvalidChrootBasePath)?,
                 // `firecracker` binary args.

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-    config::{network, Config, JailerMode},
+    config::{Config, JailerMode},
     Error,
 };
 use serde::Serialize;
@@ -338,14 +338,12 @@ impl<'m> Machine<'m> {
         trace!("{vm_id}: Configuring network...");
         // TODO: check for at least one interface.
         let network = &self.config.network_interfaces[0];
-        let network::Interface::Cni(cni) = network;
-        let iface_id = cni.vm_if_name.as_ref().unwrap_or(&cni.network_name);
         let json = json!({
-            "iface_id": iface_id,
-            "host_dev_name": cni.if_name,
+            "iface_id": network.vm_if_name,
+            "host_dev_name": network.host_if_name,
         });
         let json = serde_json::to_string(&json)?;
-        let path = format!("/network-interfaces/{}", iface_id);
+        let path = format!("/network-interfaces/{}", network.vm_if_name);
         let url: hyper::Uri = Uri::new(&self.config.socket_path, &path).into();
         let request = Request::builder()
             .method(Method::PUT)

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -339,11 +339,11 @@ impl<'m> Machine<'m> {
         // TODO: check for at least one interface.
         let network = &self.config.network_interfaces[0];
         let json = json!({
-            "iface_id": network.vm_if_name,
-            "host_dev_name": network.host_if_name,
+            "iface_id": network.vm_if_name(),
+            "host_dev_name": network.host_if_name(),
         });
         let json = serde_json::to_string(&json)?;
-        let path = format!("/network-interfaces/{}", network.vm_if_name);
+        let path = format!("/network-interfaces/{}", network.vm_if_name());
         let url: hyper::Uri = Uri::new(&self.config.socket_path, &path).into();
         let request = Request::builder()
             .method(Method::PUT)

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -117,17 +117,17 @@ impl<'m> Machine<'m> {
         // Copy all drives to the rootfs.
         for drive in &mut config.drives {
             let drive_filename = drive
-                .path_on_host
+                .path_on_host()
                 .file_name()
                 .ok_or(Error::InvalidDrivePath)?;
             let dest = jailer_workspace_dir.join(drive_filename);
             trace!(
                 "{vm_id}: Copying drive `{}` from `{}` to `{}`",
-                drive.drive_id,
-                drive.path_on_host.display(),
+                drive.drive_id(),
+                drive.path_on_host().display(),
                 dest.display()
             );
-            copy(&drive.path_on_host, dest).await?;
+            copy(&drive.path_on_host(), dest).await?;
 
             drive.path_on_host = PathBuf::from(drive_filename).into();
         }
@@ -315,7 +315,7 @@ impl<'m> Machine<'m> {
         let vm_id = self.vm_id();
         trace!("{vm_id}: Configuring drives...");
         for drive in &self.config.drives {
-            let path = format!("/drives/{}", drive.drive_id);
+            let path = format!("/drives/{}", drive.drive_id());
             let url: hyper::Uri = Uri::new(&self.config.socket_path, &path).into();
             let json = serde_json::to_string(&drive)?;
 


### PR DESCRIPTION
Builder pattern isn't just natural but also makes it easy to help user avoid mistakes in creating configurations.