### PR TITLE
Use chroot path for initrd and kernel configs, filenames for drives

### DIFF
--- a/src/config/drive.rs
+++ b/src/config/drive.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, path::Path};
 use serde::{Deserialize, Serialize};
 
 /// Drive configuration.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Drive<'d> {
     drive_id: Cow<'d, str>,
     is_read_only: bool,


### PR DESCRIPTION
`kernel_image_path` and `initrd_path` from BootSource should be populated from chrooted file path when we build the boot source config. `path_on_host` field on Drive is also updated to carry only drive filename, but only right before sending object to the socket.

Fixes a regression from https://github.com/blockjoy/firec/commit/196c88b3e026a4db645e2182df053612130f6f55.