### PR TITLE
Rename `Machine::stop()` to `force_shutdown()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Let the machine run for a bit before we KILL IT :)
     sleep(Duration::from_secs(15)).await;
 
-    machine.stop().await?;
+    machine.force_shutdown().await?;
 
     Ok(())
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -209,9 +209,11 @@ impl<'m> Machine<'m> {
         Ok(())
     }
 
-    /// Stop the machine.
+    /// Forcefully shutdown the machine.
+    ///
+    /// This will be done by killing VM process.
     #[instrument(skip_all)]
-    pub async fn stop(&self) -> Result<(), Error> {
+    pub async fn force_shutdown(&self) -> Result<(), Error> {
         let vm_id = self.config.vm_id();
         trace!("{vm_id}: Killing VM...");
 


### PR DESCRIPTION
Old name was not reflecting a forceful nature of the call.