### PR TITLE
Start jailer/firecracker process in `start` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_network_interface(iface)
         .socket_path(Path::new("/tmp/firecracker.socket"))
         .build()?;
-    let machine = Machine::create(config).await?;
+    let mut machine = Machine::create(config).await?;
 
     machine.start().await?;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,10 @@ pub enum Error {
         body: Option<String>,
     },
 
+    /// Process not started
+    #[error("Process not started")]
+    ProcessNotStarted,
+
     /// Process not running
     #[error("Process not running for pid: {0}")]
     ProcessNotRunning(i32),


### PR DESCRIPTION
This will make process management more straightforward, because we will be able to use process pid as an indicator of machine running status.