### PR TITLE
Accept `state` param in `Machine::connect` instead of `pid`

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -117,20 +117,20 @@ impl<'m> Machine<'m> {
         Ok(machine)
     }
 
-    /// Connect to already running machine.
+    /// Connect to already created machine.
     ///
-    /// The machine should be created first via call to `create`, and then started via `start`
+    /// The machine should be created first via call to `create`
     #[instrument(skip_all)]
-    pub async fn connect(config: Config<'m>, pid: i32) -> Machine<'m> {
+    pub async fn connect(config: Config<'m>, state: MachineState) -> Machine<'m> {
         let vm_id = *config.vm_id();
         info!("Connecting to machine with VM ID `{vm_id}`");
-        trace!("{vm_id}: Configuration: {:?}, pid: {}", config, pid);
+        trace!("{vm_id}: Configuration: {:?}, state: {:?}", config, state);
 
         let client = Client::unix();
 
         Self {
             config,
-            state: MachineState::RUNNING { pid },
+            state,
             client,
         }
     }


### PR DESCRIPTION
This will allow connecting to created, but not yet started machines, in order to start them.

Follows up https://github.com/blockjoy/firec/pull/17