### PR TITLE
VM ID can now be any string

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ thiserror = "1.0.31"
 tokio = {version = "1.18.1", features = ["process", "net", "fs", "rt", "time"]}
 tracing = "0.1.34"
 users = "0.11.0"
-uuid = {version = "1.0.0", features = ["serde", "v4"]}
 
 [dev-dependencies]
 doc-comment = "0.3.3"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let iface = Interface::new("eth0", "tap0");
 
-    let config = Config::builder(None, Path::new("debian-vmlinux"))
+    let config = Config::builder("butterfly-dragon-kitty", Path::new("debian-vmlinux"))
         .jailer_cfg()
             .chroot_base_dir(Path::new("/srv"))
             .exec_file(Path::new("/usr/bin/firecracker"))

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,10 +4,6 @@ use thiserror::Error;
 /// Error type for this crate.
 #[derive(Debug, Error)]
 pub enum Error {
-    /// Failed to generate UUID.
-    #[error("Failed to generate UUID: {0}")]
-    Uuid(#[from] uuid::Error),
-
     /// IO error.
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -47,7 +47,7 @@ impl<'m> Machine<'m> {
     /// The machine is not started yet.
     #[instrument(skip_all)]
     pub async fn create(config: Config<'m>) -> Result<Machine<'m>, Error> {
-        let vm_id = *config.vm_id();
+        let vm_id = config.vm_id();
         info!("Creating new machine with VM ID `{vm_id}`");
         trace!("{vm_id}: Configuration: {:?}", config);
 
@@ -123,7 +123,7 @@ impl<'m> Machine<'m> {
     /// The machine should be created first via call to `create`
     #[instrument(skip_all)]
     pub async fn connect(config: Config<'m>, state: MachineState) -> Machine<'m> {
-        let vm_id = *config.vm_id();
+        let vm_id = config.vm_id();
         info!("Connecting to machine with VM ID `{vm_id}`");
         trace!("{vm_id}: Configuration: {:?}, state: {:?}", config, state);
 
@@ -168,7 +168,7 @@ impl<'m> Machine<'m> {
                     "new-session",
                     "-d",
                     "-s",
-                    &vm_id.to_string(),
+                    &vm_id,
                     jailer.jailer_binary().to_str().unwrap(),
                 ]);
 
@@ -289,7 +289,7 @@ impl<'m> Machine<'m> {
             JailerMode::Tmux => {
                 // In case of tmux, we need to kill the tmux session.
                 let cmd = &mut Command::new("tmux");
-                cmd.args(&["kill-session", "-t", &vm_id.to_string()]);
+                cmd.args(&["kill-session", "-t", vm_id]);
                 trace!("{vm_id}: Running command: {:?}", cmd);
                 cmd.spawn()?.wait().await?;
             }


### PR DESCRIPTION
This is to allow for non-UUID compliant strings as names/IDs.