### PR TITLE
Specify license type in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.2.0"
 edition = "2021"
 keywords = ["firecracker", "unix", "linux", "microvm", "IPC"]
 categories = ["os::linux-apis", "virtualization", "web-programming::http-client"]
-license-file = "LICENSE"
+license = "Apache-2.0"
 repository = "https://github.com/blockjoy/firec/"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
With only the `license-file` specified without `license`, crates.io marks the package as using a "non-standard license".

> If a package is using a nonstandard license, then the license-file field may be specified in lieu of the license field.

- https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields

One should not use both fields at once either, but the documentation is less clear on that. Using both at the same time results in a warning:

> warning: only one of `license` or `license-file` is necessary
> `license` should be used if the package license can be expressed with a standard SPDX expression.
> `license-file` should be used if the package uses a non-standard license.
> See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.

This commit specifies the license type appropriately as Apache-2.0 for recognition on crates.io.

As a disclaimer, I work for Amazon Web Services but am not affiliated with the Firecracker teams, and I am not representing Amazon or Amazon Web Services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.